### PR TITLE
feat: verify archive checksums on download

### DIFF
--- a/src/components/DownloadProgress.tsx
+++ b/src/components/DownloadProgress.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { downloadArchive } from '@/util/archive-client';
+
+interface DownloadProgressProps {
+    /** URL to download from */
+    url: string;
+    /** Expected SHA-256 checksum returned by the API */
+    checksum: string;
+}
+
+/**
+ * Component that displays download progress and verification status.
+ */
+const DownloadProgress: React.FC<DownloadProgressProps> = ({ url, checksum }) => {
+    const [progress, setProgress] = useState(0);
+    const [verified, setVerified] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        let mounted = true;
+        const run = async () => {
+            try {
+                const result = await downloadArchive(url, checksum, setProgress);
+                if (mounted) {
+                    setVerified(result.verified);
+                }
+            } catch (err) {
+                console.error('Download failed', err);
+                if (mounted) {
+                    setVerified(false);
+                }
+            }
+        };
+        run();
+        return () => {
+            mounted = false;
+        };
+    }, [url, checksum]);
+
+    return (
+        <div className="w-full max-w-md p-4">
+            <div className="h-2 bg-gray-200 rounded">
+                <div
+                    className="h-2 bg-purdue-boilermakerGold rounded"
+                    style={{ width: `${progress}%` }}
+                />
+            </div>
+            {verified !== null && (
+                <p
+                    className={`mt-2 text-sm ${
+                        verified ? 'text-green-600' : 'text-red-600'
+                    }`}
+                >
+                    {verified ? 'Download verified' : 'Checksum mismatch'}
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default DownloadProgress;

--- a/src/util/archive-client.ts
+++ b/src/util/archive-client.ts
@@ -1,0 +1,74 @@
+/**
+ * Utility functions for downloading archives and verifying their integrity.
+ */
+
+export interface DownloadResult {
+    /** Blob representing the downloaded file */
+    blob: Blob;
+    /** Hex-encoded SHA-256 checksum of the downloaded data */
+    checksum: string;
+    /** Whether the checksum matched the expected value */
+    verified: boolean;
+}
+
+/**
+ * Compute the SHA-256 checksum for the given data using the Web Crypto API.
+ *
+ * @param data - ArrayBuffer containing the file data
+ * @returns Hex-encoded checksum string
+ */
+export async function computeSHA256(data: ArrayBuffer): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Download a file, compute its checksum and verify against the expected value.
+ *
+ * @param url - URL to download from
+ * @param expectedChecksum - Expected SHA-256 checksum (hex string)
+ * @param onProgress - Optional progress callback (0-100)
+ * @returns Object containing the downloaded blob, computed checksum and verification status
+ */
+export async function downloadArchive(
+    url: string,
+    expectedChecksum: string,
+    onProgress?: (progress: number) => void
+): Promise<DownloadResult> {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to download archive: ${response.status}`);
+    }
+
+    const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+    const reader = response.body?.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+
+    if (reader) {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) {
+                chunks.push(value);
+                received += value.length;
+                if (onProgress && contentLength) {
+                    const progress = Math.round((received / contentLength) * 100);
+                    onProgress(progress);
+                }
+            }
+        }
+    }
+
+    const blob = new Blob(chunks);
+    const buffer = await blob.arrayBuffer();
+    const checksum = await computeSHA256(buffer);
+    const verified = checksum.toLowerCase() === expectedChecksum.toLowerCase();
+
+    if (onProgress) {
+        onProgress(100);
+    }
+
+    return { blob, checksum, verified };
+}


### PR DESCRIPTION
## Summary
- add archive client with Web Crypto SHA-256 checksum verification
- show download success or checksum failure in `DownloadProgress`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa494d8483308547c44da08a41c5