### PR TITLE
Add bulk download page with time window support

### DIFF
--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -8,6 +8,8 @@ interface Props {
 const ArchiveSelector: React.FC<Props> = ({ archives }) => {
   const [selected, setSelected] = useState<ArchiveMetadata | null>(null);
   const [offset, setOffset] = useState(0);
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
 
   useEffect(() => {
     if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
@@ -23,11 +25,13 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
   }, [selected]);
 
   const post = (type: string) => {
-    if (!selected) return;
+    if (!selected || !start || !end) return;
     navigator.serviceWorker.controller?.postMessage({
       type,
       archive: selected,
       offset,
+      start,
+      end,
     });
   };
 
@@ -48,10 +52,31 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
           </option>
         ))}
       </select>
-      <div className="flex gap-2">
+      <div className="flex flex-col gap-2">
+        <div className="flex gap-2">
+          <label className="flex flex-col">
+            <span className="text-sm">Start Time</span>
+            <input
+              type="datetime-local"
+              className="border p-2"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span className="text-sm">End Time</span>
+            <input
+              type="datetime-local"
+              className="border p-2"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+            />
+          </label>
+        </div>
+        <div className="flex gap-2">
         <button
           onClick={() => post("DOWNLOAD")}
-          disabled={!selected}
+          disabled={!selected || !start || !end}
           className="bg-purdue-boilermakerGold px-4 py-2 rounded"
         >
           Start
@@ -65,11 +90,12 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
         </button>
         <button
           onClick={() => post("DOWNLOAD")}
-          disabled={!selected}
+          disabled={!selected || !start || !end}
           className="bg-green-300 px-4 py-2 rounded"
         >
           Resume
         </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ const Header = () => {
         <Link href="/">Home</Link>
         <Link href="/about">About</Link>
         <Link href="/team">Team</Link>
+        <Link href="/bulk-download">Bulk Download</Link>
         {/* <a href="/News">News</a> */}
       </nav>
     </header>

--- a/src/pages/bulk-download.tsx
+++ b/src/pages/bulk-download.tsx
@@ -16,6 +16,7 @@ const BulkDownloadPage: React.FC = () => {
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Bulk Download</h1>
+      <p className="mb-2">Select an archive and choose a time window to download data.</p>
       <ArchiveSelector archives={archives} />
       <DownloadProgress />
     </div>

--- a/src/util/archive-client.ts
+++ b/src/util/archive-client.ts
@@ -11,6 +11,7 @@ export async function fetchArchives(): Promise<ArchiveMetadata[]> {
     throw new Error("Failed to fetch archives");
   }
   return res.json();
+}
 
 /**
  * Utility functions for downloading archives and verifying their integrity.


### PR DESCRIPTION
## Summary
- add navigation link to new bulk download page
- allow users to select start and end times before downloading archives
- pass the time window through the service worker when downloading

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68994f143ec083308aea8883f86c8bdc