### PR TITLE
feat: support monthly downloads for date range

### DIFF
--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import type { ArchiveMetadata } from "../util/archive-client";
+import { getArchiveDownloadUrl } from "../util/archive-client";
 
 interface Props {
   archives: ArchiveMetadata[];
@@ -91,11 +92,10 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
 
     let completed = 0;
     for (const archive of toDownload) {
-      const downloadUrl = `/api/bulk-download/archives/download-archive?name=${encodeURIComponent(archive.name)}`;
+      const downloadUrl = getArchiveDownloadUrl(archive.name);
       const link = document.createElement("a");
       link.href = downloadUrl;
       link.download = archive.name;
-      link.target = "_blank";
       link.style.display = "none";
       document.body.appendChild(link);
       link.click();
@@ -108,15 +108,15 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
           })
         );
       }
-      // Small delay to avoid browsers blocking multiple automatic downloads
-      await new Promise((r) => setTimeout(r, 500));
+      // Delay to let each download begin before triggering the next
+      await new Promise((r) => setTimeout(r, 1000));
     }
   };
 
   const downloadDirect = () => {
     if (!selected) return;
     // Create direct download link to our API endpoint which redirects to S3
-    const downloadUrl = `/api/bulk-download/archives/download-archive?name=${encodeURIComponent(selected.name)}`;
+    const downloadUrl = getArchiveDownloadUrl(selected.name);
     const link = document.createElement('a');
     link.href = downloadUrl;
     link.download = selected.name;

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -34,11 +34,12 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
-          
+
           // Clean up blob URL if it was created
           if (data.isBlob) {
             setTimeout(() => URL.revokeObjectURL(data.url), 1000);
           }
+          setOffset(0);
         } else if (data.type === "ERROR" && selected && data.name === selected.name) {
           console.error("Download error:", data.error);
           alert(`Download failed: ${data.error}`);

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -73,19 +73,35 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
       current.setMonth(current.getMonth() + 1);
     }
 
+    const total = months.length;
+    if (total > 1) {
+      window.dispatchEvent(
+        new CustomEvent("archive-progress", { detail: { current: 0, total } })
+      );
+    }
+
+    let completed = 0;
     for (const m of months) {
       const archiveName = `${m}.zip`;
       const archive = archives.find((a) => a.name === archiveName);
       if (archive) {
         const downloadUrl = `/api/bulk-download/archives/download-archive?name=${encodeURIComponent(archive.name)}`;
-        const link = document.createElement('a');
+        const link = document.createElement("a");
         link.href = downloadUrl;
         link.download = archive.name;
-        link.target = '_blank';
-        link.style.display = 'none';
+        link.target = "_blank";
+        link.style.display = "none";
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
+        completed += 1;
+        if (total > 1) {
+          window.dispatchEvent(
+            new CustomEvent("archive-progress", {
+              detail: { current: completed, total },
+            })
+          );
+        }
         // Small delay to avoid browsers blocking multiple automatic downloads
         await new Promise((r) => setTimeout(r, 500));
       }

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -50,13 +50,13 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
   }, [selected]);
 
   const post = (type: string) => {
-    if (!selected || !start || !end) return;
+    if (!selected) return;
     navigator.serviceWorker.controller?.postMessage({
       type,
       archive: selected,
       offset,
-      start: start.toISOString(),
-      end: end.toISOString(),
+      ...(start ? { start: start.toISOString() } : {}),
+      ...(end ? { end: end.toISOString() } : {}),
     });
   };
 
@@ -113,18 +113,14 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
     }
   };
 
-  const downloadDirect = () => {
+  const downloadFull = () => {
     if (!selected) return;
-    // Create direct download link to our API endpoint which redirects to S3
-    const downloadUrl = getArchiveDownloadUrl(selected.name);
-    const link = document.createElement('a');
-    link.href = downloadUrl;
-    link.download = selected.name;
-    link.target = '_blank'; // Open in new tab to handle redirects properly
-    link.style.display = 'none';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    setOffset(0);
+    navigator.serviceWorker.controller?.postMessage({
+      type: "DOWNLOAD",
+      archive: selected,
+      offset: 0,
+    });
   };
 
   return (
@@ -183,7 +179,7 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
         {/* Action Buttons */}
         <div className="flex gap-3 flex-wrap">
           <button
-            onClick={downloadDirect}
+            onClick={downloadFull}
             disabled={!selected}
             className="bg-purdue-boilermakerGold px-6 py-3 rounded-lg text-black font-semibold hover:bg-yellow-500 disabled:bg-gray-600 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors"
           >

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -59,7 +59,7 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
     });
   };
 
-  const downloadRange = () => {
+  const downloadRange = async () => {
     if (!start || !end) return;
 
     const months: string[] = [];
@@ -73,20 +73,23 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
       current.setMonth(current.getMonth() + 1);
     }
 
-    months.forEach((m) => {
+    for (const m of months) {
       const archiveName = `${m}.zip`;
       const archive = archives.find((a) => a.name === archiveName);
       if (archive) {
         const downloadUrl = `/api/bulk-download/archives/download-archive?name=${encodeURIComponent(archive.name)}`;
-        const link = document.createElement("a");
+        const link = document.createElement('a');
         link.href = downloadUrl;
         link.download = archive.name;
-        link.style.display = "none";
+        link.target = '_blank';
+        link.style.display = 'none';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
+        // Small delay to avoid browsers blocking multiple automatic downloads
+        await new Promise((r) => setTimeout(r, 500));
       }
-    });
+    }
   };
 
   const downloadDirect = () => {

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -70,50 +70,29 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
       );
     }
 
-    const failed: string[] = [];
     let completed = 0;
     for (const archive of toDownload) {
       const url = getArchiveDownloadUrl(archive.name);
-      let blob: Blob | null = null;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const res = await fetch(url);
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          blob = await res.blob();
-          break;
-        } catch (err) {
-          if (attempt === 2) {
-            console.error("Failed to download", archive.name, err);
-            failed.push(archive.name);
-          } else {
-            await new Promise((r) => setTimeout(r, 1000));
-          }
-        }
+      // Trigger browser download without fetching to avoid CORS issues
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = archive.name;
+      link.style.display = "none";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      completed += 1;
+      if (total > 1) {
+        window.dispatchEvent(
+          new CustomEvent("archive-progress", {
+            detail: { current: completed, total },
+          })
+        );
       }
 
-      if (blob) {
-        const urlObj = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.href = urlObj;
-        link.download = archive.name;
-        link.style.display = "none";
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        setTimeout(() => URL.revokeObjectURL(urlObj), 1000);
-        await new Promise((r) => setTimeout(r, 100));
-        completed += 1;
-        if (total > 1) {
-          window.dispatchEvent(
-            new CustomEvent("archive-progress", {
-              detail: { current: completed, total },
-            })
-          );
-        }
-      }
-    }
-    if (failed.length) {
-      alert(`Failed to download: ${failed.join(", ")}`);
+      // Small delay to prevent the browser from blocking multiple downloads
+      await new Promise((r) => setTimeout(r, 200));
     }
   };
 

--- a/src/components/ArchiveSelector.tsx
+++ b/src/components/ArchiveSelector.tsx
@@ -59,6 +59,36 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
     });
   };
 
+  const downloadRange = () => {
+    if (!start || !end) return;
+
+    const months: string[] = [];
+    const current = new Date(start.getFullYear(), start.getMonth(), 1);
+    const endMonth = new Date(end.getFullYear(), end.getMonth(), 1);
+
+    while (current <= endMonth) {
+      const year = current.getFullYear();
+      const month = String(current.getMonth() + 1).padStart(2, "0");
+      months.push(`${year}-${month}`);
+      current.setMonth(current.getMonth() + 1);
+    }
+
+    months.forEach((m) => {
+      const archiveName = `${m}.zip`;
+      const archive = archives.find((a) => a.name === archiveName);
+      if (archive) {
+        const downloadUrl = `/api/bulk-download/archives/download-archive?name=${encodeURIComponent(archive.name)}`;
+        const link = document.createElement("a");
+        link.href = downloadUrl;
+        link.download = archive.name;
+        link.style.display = "none";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+    });
+  };
+
   const downloadDirect = () => {
     if (!selected) return;
     // Create direct download link to our API endpoint which redirects to S3
@@ -136,8 +166,8 @@ const ArchiveSelector: React.FC<Props> = ({ archives }) => {
             Download Full Archive
           </button>
           <button
-            onClick={() => post("DOWNLOAD")}
-            disabled={!selected || !start || !end}
+            onClick={downloadRange}
+            disabled={!start || !end}
             className="bg-blue-500 px-6 py-3 rounded-lg text-white font-semibold hover:bg-blue-600 disabled:bg-gray-600 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors"
           >
             Download Time Range

--- a/src/components/DownloadProgress.tsx
+++ b/src/components/DownloadProgress.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from "react";
 
-interface ProgressState {
+type ProgressState =
+  | { kind: "bytes"; name: string; received: number; total: number }
+  | { kind: "files"; current: number; total: number };
+
+interface SWProgressMessage {
+  type: "PROGRESS";
   name: string;
   received: number;
   total: number;
@@ -10,26 +15,58 @@ const DownloadProgress: React.FC = () => {
   const [progress, setProgress] = useState<ProgressState | null>(null);
 
   useEffect(() => {
+    const swHandler = (event: MessageEvent) => {
+      const data = event.data as SWProgressMessage;
+      if (data.type === "PROGRESS") {
+        setProgress({
+          kind: "bytes",
+          name: data.name,
+          received: data.received,
+          total: data.total,
+        });
+      }
+    };
+
+    const multiHandler = (event: Event) => {
+      const detail = (event as CustomEvent<{ current: number; total: number }>).detail;
+      setProgress({ kind: "files", current: detail.current, total: detail.total });
+    };
+
     if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
-      const handler = (event: MessageEvent) => {
-        const data = event.data as any;
-        if (data.type === "PROGRESS") {
-          setProgress({ name: data.name, received: data.received, total: data.total });
-        }
-      };
-      navigator.serviceWorker.addEventListener("message", handler);
-      return () => navigator.serviceWorker.removeEventListener("message", handler);
+      navigator.serviceWorker.addEventListener("message", swHandler);
     }
+    if (typeof window !== "undefined") {
+      window.addEventListener("archive-progress", multiHandler as EventListener);
+    }
+
+    return () => {
+      if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+        navigator.serviceWorker.removeEventListener("message", swHandler);
+      }
+      if (typeof window !== "undefined") {
+        window.removeEventListener(
+          "archive-progress",
+          multiHandler as EventListener
+        );
+      }
+    };
   }, []);
 
   if (!progress) return null;
-  const pct = (progress.received / progress.total) * 100;
+
+  let pct = 0;
+  let label = "";
+  if (progress.kind === "bytes") {
+    pct = (progress.received / progress.total) * 100;
+    label = `${progress.name}: ${pct.toFixed(1)}%`;
+  } else {
+    pct = (progress.current / progress.total) * 100;
+    label = `Downloaded ${progress.current} / ${progress.total} files`;
+  }
 
   return (
     <div className="mt-4">
-      <p>
-        {progress.name}: {pct.toFixed(1)}%
-      </p>
+      <p>{label}</p>
       <div className="w-full bg-gray-200 h-2">
         <div
           className="bg-purdue-boilermakerGold h-2"

--- a/src/pages/bulk-download.tsx
+++ b/src/pages/bulk-download.tsx
@@ -86,6 +86,9 @@ const BulkDownloadPage: React.FC = () => {
               <p className="text-gray-300 text-sm mt-4">
                 Filenames containing an <code>_S</code> are Stampede data files, <code>_C</code> are Conte data files, and filenames without these suffixes are Anvil data files. Anvil data spans June 2022 to June 2023, Conte data spans April 2015 to June 2017, and Stampede data spans February 2013 to April 2018.
               </p>
+              <p className="text-gray-300 text-sm mt-4 italic">
+                Your browser may prompt you to approve multiple downloads; please allow these prompts to ensure all files are saved.
+              </p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- allow time range downloads to fetch all archives spanning selected months
- enable Download Time Range button without selecting an archive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint errors in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ea38bd448330a7f786349b2067ea